### PR TITLE
Table of contents should link to headers

### DIFF
--- a/articles/hubs/markdown.md
+++ b/articles/hubs/markdown.md
@@ -12,17 +12,17 @@ Below is a quick reference of all the Markdown syntax that is supported by Stopl
 
 ### Table of Contents 
 
-- Headers
-- Emphasis 
-- Lists 
-- Images 
-- Code and Syntax Highlighting 
-- Tables 
-- Blockquotes 
-- Inline HTML 
-- Horizontal Rule 
-- Line Breaks 
-- Videos 
+- [Headers](#headers)
+- [Emphasis](#emphasis)
+- [Lists](#lists) 
+- [Images](#images)
+- [Code and Syntax Highlighting](#code-and-syntax-highlighting)
+- [Tables](#tables)
+- [Blockquotes](#blockquotes)
+- [Inline HTML](#inline-html)
+- [Horizontal Rule](#horizontal-rule)
+- [Line Breaks](#line-breaks)
+- [Videos](#videos)
 
 ## Headers 
 


### PR DESCRIPTION
Hashes will be created by lowercasing the header's title and replacing spaces with dashes.

For example:

"Code and Syntax Highlighting" will be turned into `#code-and-syntax-highlighting`